### PR TITLE
Add various functions to easily serialize models and lists

### DIFF
--- a/src/Components/ArrayList.php
+++ b/src/Components/ArrayList.php
@@ -5,7 +5,7 @@ namespace Afosto\ApiClient\Components;
 use Afosto\ApiClient\Components\Exceptions\ModelException;
 use Afosto\ApiClient\Components\Models\Model;
 
-class ArrayList implements \ArrayAccess, \Iterator, \Countable {
+class ArrayList implements \ArrayAccess, \Iterator, \Countable, \JsonSerializable {
 
     /**
      * Internal data object
@@ -150,5 +150,45 @@ class ArrayList implements \ArrayAccess, \Iterator, \Countable {
     public function reset() {
         $this->_data = [];
         $this->_key = 0;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->getBody(true);
+    }
+
+    /**
+     * Return the contents of this list as regular PHP array of models.
+     *
+     * @param bool $convertObjects  If this is true, all models in the list will be converted to arrays as well.
+     * @return array
+     */
+    public function getBody($convertObjects = false)
+    {
+        if ($convertObjects) {
+            return array_map(function($model){
+                return $model->getBody();
+            }, $this->_data);
+        } else {
+            return $this->_data;
+        }
+    }
+
+    /**
+     * Alias of getBody()
+     *
+     * @param bool $convertObjects
+     * @return array
+     */
+    public function toArray($convertObjects = false)
+    {
+        return $this->getBody($convertObjects);
     }
 }

--- a/src/Components/Models/Model.php
+++ b/src/Components/Models/Model.php
@@ -6,8 +6,9 @@ use Afosto\ApiClient\Components\Exceptions\ModelException;
 use Afosto\ApiClient\Components\Component;
 use Afosto\ApiClient\Components\ArrayList;
 use Afosto\ApiClient\Components\Helpers\ApiHelper;
+use JsonSerializable;
 
-abstract class Model extends Component {
+abstract class Model extends Component implements JsonSerializable {
 
     /**
      * The list of attributes
@@ -186,6 +187,26 @@ abstract class Model extends Component {
             }
         }
         return $body;
+    }
+
+    /**
+     * Return this object as array a model can easily be serialized to JSON.
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->getBody();
+    }
+
+    /**
+     * Returns this model as associative array. Alias of getBody()
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->getBody();
     }
 
     /**


### PR DESCRIPTION
- Add getBody function to ArrayList to easily convert it to an array. Pass true to it to convert all contained models as well.
- Add toArray to Model and ArrayList
- Add JsonSerializable interface to Model and ArrayList so you can easily pass a model to json_encode.
