### PR TITLE
Allow zero values to be set through Model->setAttribute()

### DIFF
--- a/src/Components/Models/Model.php
+++ b/src/Components/Models/Model.php
@@ -102,7 +102,7 @@ abstract class Model extends Component implements JsonSerializable {
      * @return bool|mixed
      */
     public function setAttribute($name, $value) {
-        if ($name == '_links') {
+        if ($value === null || $name == '_links') {
             return true;
         } else if ($this->_isRelation($name, 'many')) {
             $relation = $this->_relations[$name];

--- a/src/Components/Models/Model.php
+++ b/src/Components/Models/Model.php
@@ -94,13 +94,15 @@ abstract class Model extends Component implements JsonSerializable {
     }
 
     /**
-     * Set the attribute for the model
-     * @param $name
-     * @param $value
+     * Set an attribute on the model
+     *
+     * @param string $name The name of the attribute or relation to set
+     * @param mixed $value The value to set it to
+     *
      * @return bool|mixed
      */
     public function setAttribute($name, $value) {
-        if ($value == null || $name == '_links') {
+        if ($name == '_links') {
             return true;
         } else if ($this->_isRelation($name, 'many')) {
             $relation = $this->_relations[$name];


### PR DESCRIPTION
Previously, values equal to null could not be set, so stock for example could not be set to zero.
